### PR TITLE
CD: Migrate deployment to service repo

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -103,6 +103,7 @@ jobs:
             HELM_VALUES=/home/circleci/project/.circleci/values-staging.yaml
             sed -i "s/BTC_USER/$BTC_USER/g" $HELM_VALUES
             sed -i "s/BTC_PASSWORD/$BTC_PASSWORD/g" $HELM_VALUES
+            sed -i "s/COVENANT_SIGNER_STAGING_FQDN/$COVENANT_SIGNER_STAGING_FQDN/g" $HELM_VALUES
       - run:
           name: Perform a dry run of the new releases
           command: |
@@ -151,6 +152,7 @@ jobs:
             HELM_VALUES=/home/circleci/project/.circleci/values-testnet.yaml
             sed -i "s/BTC_USER/$BTC_USER/g" $HELM_VALUES
             sed -i "s/BTC_PASSWORD/$BTC_PASSWORD/g" $HELM_VALUES
+            sed -i "s/COVENANT_SIGNER_FQDN/$COVENANT_SIGNER_FQDN/g" $HELM_VALUES
       - run:
           name: Perform a dry run of the new release
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -103,7 +103,7 @@ jobs:
             HELM_VALUES=/home/circleci/project/.circleci/values-staging.yaml
             sed -i "s/BTC_USER/$BTC_USER/g" $HELM_VALUES
             sed -i "s/BTC_PASSWORD/$BTC_PASSWORD/g" $HELM_VALUES
-            sed -i "s/COVENANT_SIGNER_STAGING_FQDN/$COVENANT_SIGNER_STAGING_FQDN/g" $HELM_VALUES
+            sed -i "s/COVENANT_SIGNER_DOMAIN/$COVENANT_SIGNER_DOMAIN/g" $HELM_VALUES
       - run:
           name: Perform a dry run of the new releases
           command: |
@@ -152,7 +152,7 @@ jobs:
             HELM_VALUES=/home/circleci/project/.circleci/values-testnet.yaml
             sed -i "s/BTC_USER/$BTC_USER/g" $HELM_VALUES
             sed -i "s/BTC_PASSWORD/$BTC_PASSWORD/g" $HELM_VALUES
-            sed -i "s/COVENANT_SIGNER_FQDN/$COVENANT_SIGNER_FQDN/g" $HELM_VALUES
+            sed -i "s/COVENANT_SIGNER_DOMAIN/$COVENANT_SIGNER_DOMAIN/g" $HELM_VALUES
       - run:
           name: Perform a dry run of the new release
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -110,10 +110,11 @@ jobs:
             HELM_VALUES=/home/circleci/project/.circleci/values-staging.yaml
             for idx in `seq 0 2`
             do
-              sed -i "s/IDX/$idx/g" $HELM_VALUES
+              cp $HELM_VALUES /tmp/covenant-signer$idx.yaml
+              sed -i "s/IDX/$idx/g" /tmp/covenant-signer$idx.yaml
               helm upgrade --install --debug --dry-run \
                 -n $DEPLOY_STAGING_NAMESPACE \
-                --values $HELM_VALUES \
+                --values /tmp/covenant-signer$idx.yaml  \
                 --version $HELM_CHART_VERSION \
                 --set deployment.version=$CIRCLE_SHA1 \
                 covenant-signer$idx $HELM_CHART_REPO
@@ -124,10 +125,11 @@ jobs:
             HELM_VALUES=/home/circleci/project/.circleci/values-staging.yaml
             for idx in `seq 0 2`
             do
-              sed -i "s/IDX/$idx/g" $HELM_VALUES
+              cp $HELM_VALUES /tmp/covenant-signer$idx.yaml
+              sed -i "s/IDX/$idx/g" /tmp/covenant-signer$idx.yaml
               helm upgrade --install --debug --atomic --wait \
                 -n $DEPLOY_STAGING_NAMESPACE --create-namespace \
-                --values $HELM_VALUES \
+                --values /tmp/covenant-signer$idx.yaml \
                 --version $HELM_CHART_VERSION \
                 --set deployment.version=$CIRCLE_SHA1 \
                 covenant-signer$idx $HELM_CHART_REPO
@@ -159,10 +161,11 @@ jobs:
             HELM_VALUES=/home/circleci/project/.circleci/values-testnet.yaml
             for idx in `seq 0 2`
             do
-              sed -i "s/IDX/$idx/g" $HELM_VALUES
+              cp $HELM_VALUES /tmp/covenant-signer$idx.yaml
+              sed -i "s/IDX/$idx/g" /tmp/covenant-signer$idx.yaml
               helm upgrade --install --debug --dry-run \
                 -n $DEPLOY_TESTNET_NAMESPACE \
-                --values $HELM_VALUES \
+                --values /tmp/covenant-signer$idx.yaml \
                 --version $HELM_CHART_VERSION \
                 --set deployment.version=$CIRCLE_SHA1 \
                 covenant-signer$idx $HELM_CHART_REPO
@@ -173,10 +176,11 @@ jobs:
             HELM_VALUES=/home/circleci/project/.circleci/values-testnet.yaml
             for idx in `seq 0 2`
             do
-              sed -i "s/IDX/$idx/g" $HELM_VALUES
+              cp $HELM_VALUES /tmp/covenant-signer$idx.yaml
+              sed -i "s/IDX/$idx/g" /tmp/covenant-signer$idx.yaml
               helm upgrade --install --debug --atomic --wait \
                 -n $DEPLOY_TESTNET_NAMESPACE --create-namespace \
-                --values $HELM_VALUES \
+                --values /tmp/covenant-signer$idx.yaml \
                 --version $HELM_CHART_VERSION \
                 --set deployment.version=$CIRCLE_SHA1 \
                 covenant-signer$idx $HELM_CHART_REPO

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -216,17 +216,39 @@ workflows:
       - push_docker:
           requires:
             - build_docker
+          filters:
+            tags:
+              only: /.*/
+            branches:
+              only:
+                - main
+                - dev
       - deploy_staging:
           requires:
             - push_docker
-      - deploy_testnet:
+            - build_lint_test
+          filters:
+            branches:
+              only:
+                - main
+                - dev
+      - require_approval_deploy:
+          type: approval
           requires:
             - deploy_staging
-              #filters:
-              #  branches:
-              #    only:
-              #      - main
-              #      - dev
+          filters:
+            branches:
+              only:
+                - main
+                - dev
+      - deploy_testnet:
+          requires:
+            - require_approval_deploy
+          filters:
+            branches:
+              only:
+                - main
+                - dev
       - require_approval_rollback:
           type: approval
           requires:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -216,53 +216,53 @@ workflows:
       - push_docker:
           requires:
             - build_docker
-              #filters:
-              #  tags:
-              #    only: /.*/
-              #  branches:
-              #    only:
-              #      - main
-              #      - dev
+          filters:
+            tags:
+              only: /.*/
+            branches:
+              only:
+                - main
+                - dev
       - deploy_staging:
           requires:
             - push_docker
-              #- build_lint_test
-              #filters:
-              #  branches:
-              #    only:
-              #      - main
-              #      - dev
+            - build_lint_test
+          filters:
+            branches:
+              only:
+                - main
+                - dev
       - require_approval_deploy:
           type: approval
           requires:
             - deploy_staging
-              #filters:
-              #  branches:
-              #    only:
-              #      - main
-              #      - dev
+          filters:
+            branches:
+              only:
+                - main
+                - dev
       - deploy_testnet:
           requires:
             - require_approval_deploy
-              #filters:
-              #  branches:
-              #    only:
-              #      - main
-              #      - dev
+          filters:
+            branches:
+              only:
+                - main
+                - dev
       - require_approval_rollback:
           type: approval
           requires:
             - deploy_testnet
-              #filters:
-              #  branches:
-              #    only:
-              #      - main
-              #      - dev
+          filters:
+            branches:
+              only:
+                - main
+                - dev
       - rollback_testnet:
           requires:
             - require_approval_rollback
-              #filters:
-              #  branches:
-              #    only:
-              #      - main
-              #      - dev
+          filters:
+            branches:
+              only:
+                - main
+                - dev

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,6 +3,8 @@ version: 2.1
 orbs:
   go: circleci/go@1.7.3
   aws-ecr: circleci/aws-ecr@8.2.1
+  kubernetes: circleci/kubernetes@1.3.1
+  helm: circleci/helm@2.0.1
 
 jobs:
   build_lint_test:
@@ -82,6 +84,121 @@ jobs:
           repo: "$CIRCLE_PROJECT_REPONAME"
           tag: "$CIRCLE_SHA1,$CIRCLE_TAG"
 
+  deploy_staging:
+    machine:
+      image: ubuntu-2204:2024.01.1
+      resource_class: large
+    steps:
+      - checkout
+      - aws-ecr/ecr-login:
+          aws-access-key-id: AWS_ACCESS_KEY_ID
+          aws-secret-access-key: AWS_SECRET_ACCESS_KEY
+          region: "$AWS_REGION"
+      - kubernetes/install-kubeconfig:
+          kubeconfig: TESTNET_KUBECONFIG
+      - helm/install-helm-client
+      - run:
+          name: Fetch and replace config placeholders from CircleCi env vars
+          command: |
+            HELM_VALUES=/home/circleci/project/.circleci/values-staging.yaml
+            sed -i "s/BTC_USER/$BTC_USER/g" $HELM_VALUES
+            sed -i "s/BTC_PASSWORD/$BTC_PASSWORD/g" $HELM_VALUES
+      - run:
+          name: Perform a dry run of the new releases
+          command: |
+            HELM_VALUES=/home/circleci/project/.circleci/values-staging.yaml
+            for idx in `seq 0 2`
+            do
+              sed -i "s/IDX/$idx/g" $HELM_VALUES
+              helm upgrade --install --debug --dry-run \
+                -n $DEPLOY_STAGING_NAMESPACE \
+                --values $HELM_VALUES \
+                --version $HELM_CHART_VERSION \
+                --set deployment.version=$CIRCLE_SHA1 \
+                covenant-signer$idx $HELM_CHART_REPO
+            done
+      - run:
+          name: Release new service version in an atomic way
+          command: |
+            HELM_VALUES=/home/circleci/project/.circleci/values-staging.yaml
+            for idx in `seq 0 2`
+            do
+              sed -i "s/IDX/$idx/g" $HELM_VALUES
+              helm upgrade --install --debug --atomic --wait \
+                -n $DEPLOY_STAGING_NAMESPACE --create-namespace \
+                --values $HELM_VALUES \
+                --version $HELM_CHART_VERSION \
+                --set deployment.version=$CIRCLE_SHA1 \
+                covenant-signer$idx $HELM_CHART_REPO
+            done
+
+  deploy_testnet:
+    machine:
+      image: ubuntu-2204:2024.01.1
+      resource_class: large
+    steps:
+      - checkout
+      - aws-ecr/ecr-login:
+          aws-access-key-id: AWS_ACCESS_KEY_ID
+          aws-secret-access-key: AWS_SECRET_ACCESS_KEY
+          region: "$AWS_REGION"
+      - kubernetes/install-kubeconfig:
+          kubeconfig: TESTNET_KUBECONFIG
+      - helm/install-helm-client
+      - run:
+          name: Fetch and replace config placeholders from CircleCi env vars
+          command: |
+            HELM_VALUES=/home/circleci/project/.circleci/values-testnet.yaml
+            sed -i "s/BTC_USER/$BTC_USER/g" $HELM_VALUES
+            sed -i "s/BTC_PASSWORD/$BTC_PASSWORD/g" $HELM_VALUES
+      - run:
+          name: Perform a dry run of the new release
+          command: |
+            HELM_VALUES=/home/circleci/project/.circleci/values-testnet.yaml
+            for idx in `seq 0 2`
+            do
+              sed -i "s/IDX/$idx/g" $HELM_VALUES
+              helm upgrade --install --debug --dry-run \
+                -n $DEPLOY_TESTNET_NAMESPACE \
+                --values $HELM_VALUES \
+                --version $HELM_CHART_VERSION \
+                --set deployment.version=$CIRCLE_SHA1 \
+                covenant-signer$idx $HELM_CHART_REPO
+            done
+      - run:
+          name: Release new service version in an atomic way
+          command: |
+            HELM_VALUES=/home/circleci/project/.circleci/values-testnet.yaml
+            for idx in `seq 0 2`
+            do
+              sed -i "s/IDX/$idx/g" $HELM_VALUES
+              helm upgrade --install --debug --atomic --wait \
+                -n $DEPLOY_TESTNET_NAMESPACE --create-namespace \
+                --values $HELM_VALUES \
+                --version $HELM_CHART_VERSION \
+                --set deployment.version=$CIRCLE_SHA1 \
+                covenant-signer$idx $HELM_CHART_REPO
+            done
+
+  rollback_testnet:
+    machine:
+      image: ubuntu-2204:2024.01.1
+      resource_class: large
+    steps:
+      - checkout
+      - aws-ecr/ecr-login:
+          aws-access-key-id: AWS_ACCESS_KEY_ID
+          aws-secret-access-key: AWS_SECRET_ACCESS_KEY
+          region: "$AWS_REGION"
+      - kubernetes/install-kubeconfig:
+          kubeconfig: TESTNET_KUBECONFIG
+      - helm/install-helm-client
+      - run:
+          name: Rollback Helm Chart to previous release
+          command: |
+            helm rollback --cleanup-on-fail --force --recreate-pods --wait \
+              --debug -n $DEPLOY_TESTNET_NAMESPACE covenant-signer
+
 workflows:
   CI:
     jobs:
@@ -93,11 +210,53 @@ workflows:
       - push_docker:
           requires:
             - build_docker
-          filters:
-            tags:
-              only: /.*/
-            branches:
-              only:
-                - main
-                - dev
-                - logging-middleware
+              #filters:
+              #  tags:
+              #    only: /.*/
+              #  branches:
+              #    only:
+              #      - main
+              #      - dev
+      - deploy_staging:
+          requires:
+            - push_docker
+              #- build_lint_test
+              #filters:
+              #  branches:
+              #    only:
+              #      - main
+              #      - dev
+      - require_approval_deploy:
+          type: approval
+          requires:
+            - deploy_staging
+              #filters:
+              #  branches:
+              #    only:
+              #      - main
+              #      - dev
+      - deploy_testnet:
+          requires:
+            - require_approval_deploy
+              #filters:
+              #  branches:
+              #    only:
+              #      - main
+              #      - dev
+      - require_approval_rollback:
+          type: approval
+          requires:
+            - deploy_testnet
+              #filters:
+              #  branches:
+              #    only:
+              #      - main
+              #      - dev
+      - rollback_testnet:
+          requires:
+            - require_approval_rollback
+              #filters:
+              #  branches:
+              #    only:
+              #      - main
+              #      - dev

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -216,39 +216,17 @@ workflows:
       - push_docker:
           requires:
             - build_docker
-          filters:
-            tags:
-              only: /.*/
-            branches:
-              only:
-                - main
-                - dev
       - deploy_staging:
           requires:
             - push_docker
-            - build_lint_test
-          filters:
-            branches:
-              only:
-                - main
-                - dev
-      - require_approval_deploy:
-          type: approval
-          requires:
-            - deploy_staging
-          filters:
-            branches:
-              only:
-                - main
-                - dev
       - deploy_testnet:
           requires:
-            - require_approval_deploy
-          filters:
-            branches:
-              only:
-                - main
-                - dev
+            - deploy_staging
+              #filters:
+              #  branches:
+              #    only:
+              #      - main
+              #      - dev
       - require_approval_rollback:
           type: approval
           requires:

--- a/.circleci/values-staging.yaml
+++ b/.circleci/values-staging.yaml
@@ -24,7 +24,7 @@ deployment:
   nodeSelector:
     workload: "staging"
   annotations:
-    configmap.reloader.stakater.com/reload: "covenant-signer, phase1-global-config"
+    configmap.reloader.stakater.com/reload: "covenant-signerIDX, phase1-global-config"
 service:
   enabled: true
   type: NodePort
@@ -53,7 +53,7 @@ ingress:
             pathType: Prefix
             backend:
               service:
-                name: covenant-signer
+                name: covenant-signerIDX
                 port:
                   name: signer
 externalDns:

--- a/.circleci/values-staging.yaml
+++ b/.circleci/values-staging.yaml
@@ -1,0 +1,101 @@
+namespace: phase-1-staging
+name: covenant-signer
+deployment:
+  image: 490721144737.dkr.ecr.us-east-1.amazonaws.com/covenant-signer
+  version: REPLACEME
+  replicas: 1
+  ports:
+    - protocol: TCP
+      containerPort: 9791
+      name: signer
+  volumes:
+    - name: covenant-signer-configmap
+      projected:
+        sources:
+          - configMap:
+              name: covenant-signer
+          - configMap:
+              name: phase1-global-config
+  volumeMounts:
+    - name: covenant-signer-configs
+      mountPath: /home/covenant-signer/.signer
+  command: |
+    covenant-signer start --config /home/covenant-signer/.signer/config.toml
+  # TODO: Enable nodeSelector once nodegroups are provisioned
+  # nodeSelector:
+  #   workload: "staging"
+  annotations:
+    configmap.reloader.stakater.com/reload: "covenant-signer, phase1-global-config"
+service:
+  enabled: true
+  type: NodePort
+  ports:
+    - protocol: TCP
+      port: 9791
+      targetPort: signer
+      name: signer
+ingress:
+  enabled: true
+  groupName: "testnet3-internal"
+  tlsCertArn: arn:aws:acm:us-east-2:490721144737:certificate/46965f73-18c3-4b1e-9eb2-b09d87e53af1
+  scheme: "internal"
+  hosts:
+    - host: COVENANT_SIGNER_FQDN
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: ssl-redirect
+                port:
+                  name: use-annotation
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: covenant-signer
+                port:
+                  name: signer
+configFiles:
+  config.toml: |
+    # This is a TOML config file.
+    # For more information, see https://github.com/toml-lang/toml
+
+    # There are two btc related configs
+    # 1. [btc-config] is config for btc full node which should have transaction indexing
+    # enabled. This node should be synced and can be open to the public.
+    # 2. [btc-signer-config] is config for bitcoind daemon which should have only
+    # wallet functionality, it should run in separate network. This bitcoind instance
+    # will be used to sign psbt's
+    [btc-config]
+    # Btc node host
+    host = "bitcoind-staging.bitcoind-signet:38332"
+    # Btc node user
+    user = BTC_USER
+    # Btc node password
+    pass = BTC_PASSWORD
+    # Btc network (testnet3|mainnet|regtest|simnet|signet)
+    network = "signet"
+
+    [btc-signer-config]
+    # Btc node host
+    host = "bitcoind-offline-wallet-IDX.bitcoind-signet:38332/wallet/covenant"
+    # Btc node user
+    user = BTC_USER
+    # Btc node password
+    pass = BTC_PASSWORD
+    # Btc network (testnet3|mainnet|regtest|simnet|signet)
+    network = "signet"
+
+    [server-config]
+    # The address to listen on
+    host = "0.0.0.0"
+    # The port to listen on
+    port = 9791
+    # Read timeout in seconds
+    read-timeout = 15
+    # Write timeout in seconds
+    write-timeout = 15
+    # Idle timeout in seconds
+    idle-timeout = 120

--- a/.circleci/values-staging.yaml
+++ b/.circleci/values-staging.yaml
@@ -74,9 +74,9 @@ configFiles:
     # Btc node host
     host = "bitcoind-staging.bitcoind-signet:38332"
     # Btc node user
-    user = BTC_USER
+    user = "BTC_USER"
     # Btc node password
-    pass = BTC_PASSWORD
+    pass = "BTC_PASSWORD"
     # Btc network (testnet3|mainnet|regtest|simnet|signet)
     network = "signet"
 
@@ -84,9 +84,9 @@ configFiles:
     # Btc node host
     host = "bitcoind-offline-wallet-IDX.bitcoind-signet:38332/wallet/covenant"
     # Btc node user
-    user = BTC_USER
+    user = "BTC_USER"
     # Btc node password
-    pass = BTC_PASSWORD
+    pass = "BTC_PASSWORD"
     # Btc network (testnet3|mainnet|regtest|simnet|signet)
     network = "signet"
 

--- a/.circleci/values-staging.yaml
+++ b/.circleci/values-staging.yaml
@@ -1,5 +1,5 @@
 namespace: phase-1-staging
-name: covenant-signer
+name: covenant-signerIDX
 deployment:
   image: 490721144737.dkr.ecr.us-east-1.amazonaws.com/covenant-signer
   version: REPLACEME

--- a/.circleci/values-staging.yaml
+++ b/.circleci/values-staging.yaml
@@ -21,9 +21,8 @@ deployment:
       mountPath: /home/covenant-signer/.signer
   command: |
     covenant-signer start --config /home/covenant-signer/.signer/config.toml
-  # TODO: Enable nodeSelector once nodegroups are provisioned
-  # nodeSelector:
-  #   workload: "staging"
+  nodeSelector:
+    workload: "staging"
   annotations:
     configmap.reloader.stakater.com/reload: "covenant-signer, phase1-global-config"
 service:

--- a/.circleci/values-staging.yaml
+++ b/.circleci/values-staging.yaml
@@ -13,7 +13,7 @@ deployment:
       projected:
         sources:
           - configMap:
-              name: covenant-signer
+              name: covenant-signerIDX
           - configMap:
               name: phase1-global-config
   volumeMounts:

--- a/.circleci/values-staging.yaml
+++ b/.circleci/values-staging.yaml
@@ -9,7 +9,7 @@ deployment:
       containerPort: 9791
       name: signer
   volumes:
-    - name: covenant-signer-configmap
+    - name: covenant-signer-configs
       projected:
         sources:
           - configMap:

--- a/.circleci/values-staging.yaml
+++ b/.circleci/values-staging.yaml
@@ -39,7 +39,7 @@ ingress:
   tlsCertArn: arn:aws:acm:us-east-2:490721144737:certificate/46965f73-18c3-4b1e-9eb2-b09d87e53af1
   scheme: "internal"
   hosts:
-    - host: COVENANT_SIGNER_FQDN
+    - host: covenant-signer-stagingIDX.COVENANT_SIGNER_DOMAIN
       http:
         paths:
           - path: /
@@ -56,6 +56,9 @@ ingress:
                 name: covenant-signer
                 port:
                   name: signer
+externalDns:
+  fqdn: covenant-signer-stagingIDX.COVENANT_SIGNER_DOMAIN
+  ttl: 60
 configFiles:
   config.toml: |
     # This is a TOML config file.

--- a/.circleci/values-testnet.yaml
+++ b/.circleci/values-testnet.yaml
@@ -74,9 +74,9 @@ configFiles:
     # Btc node host
     host = "bitcoind.bitcoind-signet:38332"
     # Btc node user
-    user = BTC_USER
+    user = "BTC_USER"
     # Btc node password
-    pass = BTC_PASSWORD
+    pass = "BTC_PASSWORD"
     # Btc network (testnet3|mainnet|regtest|simnet|signet)
     network = "signet"
 
@@ -84,9 +84,9 @@ configFiles:
     # Btc node host
     host = "bitcoind-offline-wallet-IDX.bitcoind-signet:38332/wallet/covenant"
     # Btc node user
-    user = BTC_USER
+    user = "BTC_USER"
     # Btc node password
-    pass = BTC_PASSWORD
+    pass = "BTC_PASSWORD"
     # Btc network (testnet3|mainnet|regtest|simnet|signet)
     network = "signet"
 

--- a/.circleci/values-testnet.yaml
+++ b/.circleci/values-testnet.yaml
@@ -39,7 +39,7 @@ ingress:
   tlsCertArn: arn:aws:acm:us-east-2:490721144737:certificate/46965f73-18c3-4b1e-9eb2-b09d87e53af1
   scheme: "internet-facing"
   hosts:
-    - host: COVENANT_SIGNER_FQDN
+    - host: covenant-signerIDX.COVENANT_SIGNER_DOMAIN
       http:
         paths:
           - path: /
@@ -56,6 +56,9 @@ ingress:
                 name: covenant-signer
                 port:
                   name: signer
+externalDns:
+  fqdn: covenant-signerIDX.COVENANT_SIGNER_DOMAIN
+  ttl: 60
 configFiles:
   config.toml: |
     # This is a TOML config file.

--- a/.circleci/values-testnet.yaml
+++ b/.circleci/values-testnet.yaml
@@ -24,7 +24,7 @@ deployment:
   nodeSelector:
     workload: "btc"
   annotations:
-    configmap.reloader.stakater.com/reload: "covenant-signer, phase1-global-config"
+    configmap.reloader.stakater.com/reload: "covenant-signerIDX, phase1-global-config"
 service:
   enabled: true
   type: NodePort
@@ -53,7 +53,7 @@ ingress:
             pathType: Prefix
             backend:
               service:
-                name: covenant-signer
+                name: covenant-signerIDX
                 port:
                   name: signer
 externalDns:

--- a/.circleci/values-testnet.yaml
+++ b/.circleci/values-testnet.yaml
@@ -21,9 +21,8 @@ deployment:
       mountPath: /home/covenant-signer/.signer
   command: |
     covenant-signer start --config /home/covenant-signer/.signer/config.toml
-  # TODO: Enable nodeSelector once nodegroups are provisioned
-  # nodeSelector:
-  #   workload: "btc"
+  nodeSelector:
+    workload: "btc"
   annotations:
     configmap.reloader.stakater.com/reload: "covenant-signer, phase1-global-config"
 service:

--- a/.circleci/values-testnet.yaml
+++ b/.circleci/values-testnet.yaml
@@ -1,0 +1,101 @@
+namespace: covenant-signer
+name: covenant-signer
+deployment:
+  image: 490721144737.dkr.ecr.us-east-1.amazonaws.com/covenant-signer
+  version: REPLACEME
+  replicas: 1
+  ports:
+    - protocol: TCP
+      containerPort: 9791
+      name: signer
+  volumes:
+    - name: covenant-signer-configmap
+      projected:
+        sources:
+          - configMap:
+              name: covenant-signer
+          - configMap:
+              name: phase1-global-config
+  volumeMounts:
+    - name: covenant-signer-configs
+      mountPath: /home/covenant-signer/.signer
+  command: |
+    covenant-signer start --config /home/covenant-signer/.signer/config.toml
+  # TODO: Enable nodeSelector once nodegroups are provisioned
+  # nodeSelector:
+  #   workload: "btc"
+  annotations:
+    configmap.reloader.stakater.com/reload: "covenant-signer, phase1-global-config"
+service:
+  enabled: true
+  type: NodePort
+  ports:
+    - protocol: TCP
+      port: 9791
+      targetPort: signer
+      name: signer
+ingress:
+  enabled: true
+  groupName: "testnet3-public"
+  tlsCertArn: arn:aws:acm:us-east-2:490721144737:certificate/46965f73-18c3-4b1e-9eb2-b09d87e53af1
+  scheme: "internet-facing"
+  hosts:
+    - host: COVENANT_SIGNER_FQDN
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: ssl-redirect
+                port:
+                  name: use-annotation
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: covenant-signer
+                port:
+                  name: signer
+configFiles:
+  config.toml: |
+    # This is a TOML config file.
+    # For more information, see https://github.com/toml-lang/toml
+
+    # There are two btc related configs
+    # 1. [btc-config] is config for btc full node which should have transaction indexing
+    # enabled. This node should be synced and can be open to the public.
+    # 2. [btc-signer-config] is config for bitcoind daemon which should have only
+    # wallet functionality, it should run in separate network. This bitcoind instance
+    # will be used to sign psbt's
+    [btc-config]
+    # Btc node host
+    host = "bitcoind.bitcoind-signet:38332"
+    # Btc node user
+    user = BTC_USER
+    # Btc node password
+    pass = BTC_PASSWORD
+    # Btc network (testnet3|mainnet|regtest|simnet|signet)
+    network = "signet"
+
+    [btc-signer-config]
+    # Btc node host
+    host = "bitcoind-offline-wallet-IDX.bitcoind-signet:38332/wallet/covenant"
+    # Btc node user
+    user = BTC_USER
+    # Btc node password
+    pass = BTC_PASSWORD
+    # Btc network (testnet3|mainnet|regtest|simnet|signet)
+    network = "signet"
+
+    [server-config]
+    # The address to listen on
+    host = "0.0.0.0"
+    # The port to listen on
+    port = 9791
+    # Read timeout in seconds
+    read-timeout = 15
+    # Write timeout in seconds
+    write-timeout = 15
+    # Idle timeout in seconds
+    idle-timeout = 120

--- a/.circleci/values-testnet.yaml
+++ b/.circleci/values-testnet.yaml
@@ -1,5 +1,5 @@
 namespace: covenant-signer
-name: covenant-signer
+name: covenant-signerIDX
 deployment:
   image: 490721144737.dkr.ecr.us-east-1.amazonaws.com/covenant-signer
   version: REPLACEME

--- a/.circleci/values-testnet.yaml
+++ b/.circleci/values-testnet.yaml
@@ -13,7 +13,7 @@ deployment:
       projected:
         sources:
           - configMap:
-              name: covenant-signer
+              name: covenant-signerIDX
           - configMap:
               name: phase1-global-config
   volumeMounts:

--- a/.circleci/values-testnet.yaml
+++ b/.circleci/values-testnet.yaml
@@ -9,7 +9,7 @@ deployment:
       containerPort: 9791
       name: signer
   volumes:
-    - name: covenant-signer-configmap
+    - name: covenant-signer-configs
       projected:
         sources:
           - configMap:


### PR DESCRIPTION
Phase-1 service deployment will be handled exclusively through CircleCI and the service repo.

Helm Values that include service configuration are migrated under the .circleci folder, broken by envs. Secrets now live on CircleCI params

The Staking API pipeline is used as a model (excluding the MongoDB-specific flow):
https://app.circleci.com/pipelines/github/babylonchain/staking-api-service/273/workflows/547502ea-3fcd-4556-8356-5e85592aed1e

Note: Flux repository is still holding the global-params configuration