### PR TITLE
Use confirmation instead of depth

### DIFF
--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -85,6 +85,8 @@ signet network):
 ```shell
 # Accept command line and JSON-RPC commands
 server=1
+# Enable transaction indexing
+txindex=1
 # RPC server settings
 rpcuser=<rpc-username>
 rpcpassword=<rpc-password>
@@ -93,11 +95,11 @@ rpcpassword=<rpc-password>
 # node will operate; for this example, utilizing signet
 signet=1
 [signet]
-# port your bitcoin node will listen for incoming requests
+# Port your bitcoin node will listen for incoming requests;
 # below port is the canonical port for signet,
-# for mainnet, typically 8332 is used.
+# for mainnet, typically 8332 is used
 rpcport=38332
-# address your bitcoin node will listen for incoming requests
+# Address your bitcoin node will listen for incoming requests
 rpcbind=0.0.0.0
 # Optional: Needed for remote node connectivity
 rpcallowip=0.0.0.0/0

--- a/itest/e2e_test.go
+++ b/itest/e2e_test.go
@@ -261,8 +261,8 @@ func (tm *TestManager) sendStakingTxToBtc(d *stakingData) *stakingTxSigInfo {
 
 	hash, err := tm.btcClient.SendTx(tx)
 	require.NoError(tm.t, err)
-	// generate blocks to make sure tx will be included into chain
-	_ = tm.bitcoindHandler.GenerateBlocks(int(tm.confirmationDepth + 1))
+	// generate exact amount of block to confirm staking tx
+	_ = tm.bitcoindHandler.GenerateBlocks(int(tm.confirmationDepth))
 	return &stakingTxSigInfo{
 		stakingTxHash: hash,
 		stakingOutput: info.StakingOutput,


### PR DESCRIPTION
- uses confirmation instead of depth for staking tx
- uses signed number to calculate confirmation to handle edge case of asking for tx and best block durin re-org